### PR TITLE
343 fix empty group dropdown in edit tag

### DIFF
--- a/packages/app/src/components/edit-tag/EditTag.vue
+++ b/packages/app/src/components/edit-tag/EditTag.vue
@@ -105,6 +105,11 @@ export default defineComponent({
         });
       }
 
+      // add group name of currentTag if it isn't in the database yet
+      if (!groupNames.value.includes(currentTag.value.group)) {
+        groupNames.value.push(currentTag.value.group);
+      }
+
       groupNames.value.map((groupName: string) =>
         groupListItems.value.push(new ListItem(groupName, groupName))
       );


### PR DESCRIPTION
closes #343 

- adds group name of currenttag in dropdown to list of all group names