### PR TITLE
fix tag sizing on homescreen

### DIFF
--- a/packages/app/src/views/Home.vue
+++ b/packages/app/src/views/Home.vue
@@ -23,7 +23,7 @@
             <TagEntry
               v-for="entry in group.tags"
               :key="entry.nfcData"
-              class="m-4 w-2/6 flex-shrink-0 text-4xl"
+              class="m-4 w-44 flex-shrink-0 text-4xl"
               :class="{ 'opacity-25': selectedTag !== entry && selectedTag !== null }"
               :img="entry.imageUrl"
               :name="entry.name"


### PR DESCRIPTION
sometimes this happens:

![image](https://user-images.githubusercontent.com/9517685/107069997-ff64d480-67e2-11eb-88b3-6256a7b127ab.png)


now it doesnt